### PR TITLE
fix missing dependency of gem 'rack-protection'

### DIFF
--- a/composer.rb
+++ b/composer.rb
@@ -94,6 +94,7 @@ say 'Applying redis & sidekiq...'
 gem 'redis-namespace'
 gem 'sidekiq'
 gem 'sinatra', github: 'sinatra', require: false
+gem 'rack-protection', github: 'sinatra/rack-protection', require: false
 get_remote('config/initializers/sidekiq.rb')
 get_remote('config/routes.rb')
 


### PR DESCRIPTION
目前使用此 template 会报错：

```
Bundler could not find compatible versions for gem "rack-protection":
  In Gemfile:
    sinatra was resolved to 2.0.0.pre.alpha, which depends on
      rack-protection (~> 2.0)

Could not find gem 'rack-protection (~> 2.0)', which is required by gem 'sinatra', in any of the sources.
```

rack-protection gem 目前无 2.0 版本，所以添加 github 版本
