### PR TITLE
Fix remove assets for new Rails 6 apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Then,
 
 2. Create your own rails app applying `rails-template`
 
-    `$ rails new myapp -m https://raw.githubusercontent.com/dao42/rails-template/master/composer.rb`
+    `$ rails new myapp --skip-sprockets -m https://raw.githubusercontent.com/dao42/rails-template/master/composer.rb`
 
     Important!! replace `myapp` to your real project name, we will generate lots of example files by this name.
 


### PR DESCRIPTION
Add `--skip-sprockets` to `rails new` command, in order to generate new apps without any Sprockets dependencies.

Sprockets remains the recommended mechanism for managing assets.
https://github.com/rails/rails/issues/29749#issuecomment-319609669

Because of this, a new Rails app generates Sprockets dependencies and raise `Expected to find a manifest file` exception.

This PR fix this.